### PR TITLE
Convert TCS-IRIS ICD (CCR08) to model files

### DIFF
--- a/csro/oiwfs-adc-assembly/publish-model.conf
+++ b/csro/oiwfs-adc-assembly/publish-model.conf
@@ -3,73 +3,45 @@ component = oiwfs-adc-assembly
 
 publish {
 
-  description = """
-  The ADC assembly publishes the offsets that they incur so that the TCS can correctly positions the POAs.
-        """
-
   telemetry = [
     {
-      name = "oiwfs1WfsShift"
+      name = oiwfsShift
       description = """
-The expected shifts of the IRIS OIWFS probe 1 position due to ADC effects in the X,Y plane of ICRS.
-            """
+IRIS publishes the expected ADC image shifts of the OIWFS position demands
+      """
+      minRate = 1
+      maxRate = 1
       archive = true
       attributes = [
         {
-          name = x
-          description = "x offset"
-          type = double
-          units = mm
+          name = oiwfs1Shift
+          description = "2 element array holding x, y values in the ICRS, evaluated at the reference wavelength"
+          type = array
+          dimensions: [2]
+          items = {
+            type = double
+            units = mm
+          }
         }
         {
-          name = y
-          description = "y offset"
-          type = double
-          units = mm
-        }
-      ]
-    }
-
-    {
-      name = "oiwfs2WfsShift"
-      description = """
-The expected shifts of the IRIS OIWFS probe 2 position due to ADC effects in the X,Y plane of ICRS.
-            """
-      archive = true
-      attributes = [
-        {
-          name = x
-          description = "x offset"
-          type = double
-          units = mm
+          name = oiwfs2Shift
+          description = "2 element array holding x, y values in the ICRS, evaluated at the reference wavelength"
+          type = array
+          dimensions: [2]
+          items = {
+            type = double
+            units = mm
+          }
         }
         {
-          name = y
-          description = "y offset"
-          type = double
-          units = mm
-        }
-      ]
-    }
-
-    {
-      name = "oiwfs3WfsShift"
-      description = """
-The expected shifts of the IRIS OIWFS probe 3 position due to ADC effects in the X,Y plane of ICRS.
-            """
-      archive = true
-      attributes = [
-        {
-          name = x
-          description = "x offset"
-          type = double
-          units = mm
-        }
-        {
-          name = y
-          description = "y offset"
-          type = double
-          units = mm
+          name = oiwfs3Shift
+          description = "2 element array holding x, y values in the ICRS, evaluated at the reference wavelength"
+          type = array
+          dimensions: [2]
+          items = {
+            type = double
+            units = mm
+          }
         }
       ]
     }

--- a/csro/oiwfs-adc-assembly/publish-model.conf
+++ b/csro/oiwfs-adc-assembly/publish-model.conf
@@ -8,6 +8,8 @@ publish {
       name = oiwfsShift
       description = """
 IRIS publishes the expected ADC image shifts of the OIWFS position demands
+
+      *The ADC will shift an image position in a manner that depends upon the current state of the ADC. The estimated image shift is sent from IRIS to the TCS so that the TCS can adjust the IRIS OIWFS position demands accordingly. The reference wavelength used to calculate the shift for each of the WFS is tcs.cm.iris.oiwfsXCurAtmDispersion.referenceWavelength.*
       """
       minRate = 1
       maxRate = 1

--- a/csro/oiwfs-adc-assembly/subscribe-model.conf
+++ b/csro/oiwfs-adc-assembly/subscribe-model.conf
@@ -8,18 +8,45 @@ subscribe {
           component = cmIRIS
           name = oiwfs1CurAtmDispersion
           }
-
+          {
+          subsystem = TCS
+          component = cmIRIS
+          name = oiwfs1NewAtmDispersion
+          }
           {
           subsystem = TCS
           component = cmIRIS
           name = oiwfs2CurAtmDispersion
           }
-
+          {
+          subsystem = TCS
+          component = cmIRIS
+          name = oiwfs2NewAtmDispersion
+          }
           {
           subsystem = TCS
           component = cmIRIS
           name = oiwfs3CurAtmDispersion
           }
-
+          {
+          subsystem = TCS
+          component = cmIRIS
+          name = oiwfs3NewAtmDispersion
+          }
+          {
+          subsystem = TCS
+          component = cmIRIS
+          name = oiwfs1pointingStatus
+          }
+          {
+          subsystem = TCS
+          component = cmIRIS
+          name = oiwfs2pointingStatus
+          }
+          {
+          subsystem = TCS
+          component = cmIRIS
+          name = oiwfs3pointingStatus
+          }
           ]
 }

--- a/csro/oiwfs-poa-assembly/subscribe-model.conf
+++ b/csro/oiwfs-poa-assembly/subscribe-model.conf
@@ -6,21 +6,7 @@ subscribe {
           {
           subsystem = TCS
           component = cmIRIS
-          name = oiwfs1Pos
+          name = oiwfsProbeDemands
           }
-
-          {
-          subsystem = TCS
-          component = cmIRIS
-          name = oiwfs2Pos
-          }
-
-          {
-          subsystem = TCS
-          component = cmIRIS
-          name = oiwfs3Pos
-          }
-
-
           ]
 }

--- a/imager/adc-assembly/publish-model.conf
+++ b/imager/adc-assembly/publish-model.conf
@@ -223,7 +223,11 @@ Current status of prism 2 axis. Meaning of each value is as follows:
 
 	 {
     	name = odgwShift
-    	description = "IRIS publishes the expected ADC image shifts of the (up to 4) IRIS ODGW position demands"
+    	description = """
+        IRIS publishes the expected ADC image shifts of the (up to 4) IRIS ODGW position demands
+
+        *Discussion: The ADC will shift an image position in a manner that depends upon the current state of the ADC. The estimated image shift (inferred from optical models) is sent from IRIS to the TCS so that the TCS can adjust the IRIS ODGW position demands accordingly. The reference wavelength used to calculate the shift is tcs.cm.iris.imgCurAtmDispersion.referenceWavelength.*
+        """
     	minRate = 1
     	maxRate = 1
     	archive = true

--- a/imager/adc-assembly/publish-model.conf
+++ b/imager/adc-assembly/publish-model.conf
@@ -220,6 +220,59 @@ Current status of prism 2 axis. Meaning of each value is as follows:
     		}
     	]
     }
+
+	 {
+    	name = odgwShift
+    	description = "IRIS publishes the expected ADC image shifts of the (up to 4) IRIS ODGW position demands"
+    	minRate = 1
+    	maxRate = 1
+    	archive = true
+    	archiveRate = 1
+    	attributes = [
+    		{
+    			name = odgw1Shift
+    			description  = "2 element array holding x, y values in the ICRS, evaluated at the reference wavelength"
+    			type = array
+                        dimensions: [2]
+                        items = {
+                              type = double
+                              units = mm
+                              }
+    		}
+    		{
+    			name = odgw2Shift
+    			description  = "2 element array holding x, y values in the ICRS, evaluated at the reference wavelength"
+    			type = array
+                        dimensions: [2]
+                        items = {
+                              type = double
+                              units = mm
+                              }
+    		}
+    		{
+    			name = odgw3Shift
+    			description  = "2 element array holding x, y values in the ICRS, evaluated at the reference wavelength"
+    			type = array
+                        dimensions: [2]
+                        items = {
+                              type = double
+                              units = mm
+                              }
+    		}
+    		{
+    			name = odgw4Shift
+    			description  = "2 element array holding x, y values in the ICRS, evaluated at the reference wavelength"
+    			type = array
+                        dimensions: [2]
+                        items = {
+                              type = double
+                              units = mm
+                              }
+    		}
+
+    	]
+	}
+
 ]
 
 }

--- a/imager/adc-assembly/subscribe-model.conf
+++ b/imager/adc-assembly/subscribe-model.conf
@@ -1,0 +1,22 @@
+subsystem = IRIS
+component = imager-adc-assembly
+
+subscribe {
+          telemetry = [
+          {
+          subsystem = TCS
+          component = cmIRIS
+          name = imgCurAtmDispersion
+          }
+          {
+          subsystem = TCS
+          component = cmIRIS
+          name = imgNewAtmDispersion
+          }
+          {
+          subsystem = TCS
+          component = pk
+          name = pointingStatus
+          }
+          ]
+}

--- a/imager/coldstop-assembly/subscribe-model.conf
+++ b/imager/coldstop-assembly/subscribe-model.conf
@@ -1,12 +1,12 @@
 subsystem = IRIS
-component = rotator-assembly
+component = coldstop-assembly
 
 subscribe {
           telemetry = [
           {
           subsystem = TCS
           component = cmIRIS
-          name = instrumentRotatorAngle
+          name = pupilRotation
           }
           ]
 }

--- a/imager/odgw-assembly/subscribe-model.conf
+++ b/imager/odgw-assembly/subscribe-model.conf
@@ -1,12 +1,12 @@
 subsystem = IRIS
-component = rotator-assembly
+component = imager-odgw-assembly
 
 subscribe {
           telemetry = [
           {
           subsystem = TCS
           component = cmIRIS
-          name = instrumentRotatorAngle
+          name = odgwPosDemands
           }
           ]
 }


### PR DESCRIPTION
This pull request is meant to be a literal translation of the TCD-IRIS ICD (CCR08) to model files (see most recent version of Document-25887 on TMT docushare). Obviously, the changes here affect only the portions of the interface implemented by IRIS. For those items implemented by TCS, see the [sister pull request for TCS](https://github.com/chrisaj5/TCS-Model-Files/pull/1).