### PR TITLE
Alarms from imager

### DIFF
--- a/imager/adc-assembly/publish-model.conf
+++ b/imager/adc-assembly/publish-model.conf
@@ -1441,8 +1441,8 @@ __TBD__: Maybe it would be useful to map this value to the range between 0 to 1 
           dimensions: [2]
           items = {
             type = float
-            units = mm
           }
+          units = mm
         }
         {
           name = supressSoftwareLimitAlarm

--- a/imager/adc-assembly/publish-model.conf
+++ b/imager/adc-assembly/publish-model.conf
@@ -1434,7 +1434,75 @@ __TBD__: Maybe it would be useful to map this value to the range between 0 to 1 
           minimum = 0.25
           maximum = 64
         }
+        {
+          name = softwareLimits
+          description = "Software limits of the retraction axis. If the positioner goes over this range, an alarm is activated."
+          type = array
+          dimensions: [2]
+          items = {
+            type = float
+            units = mm
+          }
+        }
+        {
+          name = supressSoftwareLimitAlarm
+          description = "Indicates whether the alarm for the software limits is supressed. This configuration is useful to supress the alarm when an instrument specialist forcibly moves the retraction axis (using engineering screen) over the software limit range for maintenance."
+          type = boolean
+          default = false
+        }
       ]
+    }
+  ]
+
+  alarms = [
+    {
+      name = retractionAxisSoftwareLimit
+      description = """
+This alarm is activated when the retraction axis goes beyond a software limit. This alarm may be activated when someone forcibly moves the retraction axis beyond the software limit by using engineering screen, or by directly sending commands to the motion controller. Because the current position is inferred from the total number of pulses sent from the motion controller after the last homing, this alarm may be activated during homing after step-out occurs.
+
+This alarm should not happen during an observation. If it does, this alarm should be reported to an instrument expert.
+"""
+      severity = minor
+      archive = true
+    }
+    {
+      name = retractionAxisHardwareLimit
+      description = """
+This alarm is activated when the retraction axis hits a limit switch.
+
+If the retraction axis is still moving beyonds the limit switch, the operator should immediately stop the motion by sending stop command. If the motion controller does not stop even after that, the operator should turn off the motion controller. Because there is a mechanical block at each end, the linear stage will not derail from the linear guide even if the linear stage goes over the limit switch, but the hitting the mechanical block may cause unnecessary damage to the mechanisms, so the motion should be stopped immediately.
+
+This alarm should not happen during an observation. If it does, this alarm should be reported to an instrument expert. If the linear stage goed beyond the limit switch, the instrument expert has to forcibly move it back to an operational range using an engineering screen.
+"""
+      severity = major
+      archive = true
+    }
+    {
+      name = stall
+      description = """
+This alarm is activated when a severe stall (step-out) of any axis is detected. The actual scheme to detect the stall is TBD.
+"""
+      severity = major
+      archive = true
+    }
+    {
+      name = trackingFailure
+      description = """
+This alarm is activated when tracking motion cannot continue properly.
+
+Note that tracking failure caused by step-out cannot be detected during the tracking motion because there is no position sensor except the home switch. This alarm just indicates that responses from the motion controller are delayed for some reason. Most probably it is caused by network congestion within IRIS private network.
+
+If the alarm stays activated for a long time, or if this alarm happens repeatedly, the following actions may resolve this issue.
+
+* Reload of this assembly.
+* Reload the underlying Galil HCD.
+* Cycliing the power of the motion controller.
+* Reboot the computer which runs this assembly and Galil HCD.
+
+If this alarm cannot be deactivated by the above actions, it should be reported to an instrument expert.
+"""
+      severity = minor
+      archive = true
     }
   ]
 }

--- a/imager/coldstop-assembly/publish-model.conf
+++ b/imager/coldstop-assembly/publish-model.conf
@@ -934,6 +934,22 @@ __TBD__: Maybe it would be useful to map this value to the range between 0 to 1 
           minimum = 0.25
           maximum = 64
         }
+        {
+          name = softwareLimits
+          description = "Software limits of X axis. If the positioner goes over this range, an alarm is activated."
+          type = array
+          dimensions: [2]
+          items = {
+            type = float
+          }
+          units = mm
+        }
+        {
+          name = supressSoftwareLimitAlarm
+          description = "Indicates whether the alarm for the software limits is supressed. This configuration is useful to supress the alarm when an instrument specialist forcibly moves X axis (using engineering screen) over the software limit range for maintenance."
+          type = boolean
+          default = false
+        }
       ]
     }
     {
@@ -1277,6 +1293,22 @@ __TBD__: Maybe it would be useful to map this value to the range between 0 to 1 
           type = float
           minimum = 0.25
           maximum = 64
+        }
+        {
+          name = softwareLimits
+          description = "Software limits of Y axis. If the positioner goes over this range, an alarm is activated."
+          type = array
+          dimensions: [2]
+          items = {
+            type = float
+          }
+            units = mm
+        }
+        {
+          name = supressSoftwareLimitAlarm
+          description = "Indicates whether the alarm for the software limits is supressed. This configuration is useful to supress the alarm when an instrument specialist forcibly moves Y axis (using engineering screen) over the software limit range for maintenance."
+          type = boolean
+          default = false
         }
       ]
     }

--- a/imager/coldstop-assembly/publish-model.conf
+++ b/imager/coldstop-assembly/publish-model.conf
@@ -1281,4 +1281,78 @@ __TBD__: Maybe it would be useful to map this value to the range between 0 to 1 
       ]
     }
   ]
+
+  alarms = [
+    {
+      name = xAxisSoftwareLimit
+      description = """
+This alarm is activated when X axis goes beyond a software limit. This alarm may be activated when someone forcibly moves X axis beyond the software limit by using engineering screen, or by directly sending commands to the motion controller. Because the current position is inferred from the total number of pulses sent from the motion controller after the last homing, this alarm may be activated during homing after step-out occurs.
+
+This alarm should not happen during an observation. If it does, this alarm should be reported to an instrument expert.
+"""
+      severity = minor
+      archive = true
+    }
+    {
+      name = xAxisHardwareLimit
+      description = """
+This alarm is activated when X axis hits a limit switch.
+
+If X axis is still moving beyonds the limit switch, the operator should immediately stop the motion by sending stop command. If the motion controller does not stop even after that, the operator should turn off the motion controller. Because there is a mechanical block at each end, the linear stage will not derail from the linear guide even if the linear stage goes over the limit switch, but the hitting the mechanical block may cause unnecessary damage to the mechanisms, so the motion should be stopped immediately.
+
+This alarm should not happen during an observation. If it does, this alarm should be reported to an instrument expert. If the linear stage goed beyond the limit switch, the instrument expert has to forcibly move it back to an operational range using an engineering screen.
+"""
+      severity = major
+      archive = true
+    }
+    {
+      name = yAxisSoftwareLimit
+      description = """
+This alarm is activated when Y axis goes beyond a software limit. This alarm may be activated when someone forcibly moves Y axis beyond the software limit by using engineering screen, or by directly sending commands to the motion controller. Because the current position is inferred from the total number of pulses sent from the motion controller after the last homing, this alarm may be activated during homing after step-out occurs.
+
+This alarm should not happen during an observation. If it does, this alarm should be reported to an instrument expert.
+"""
+      severity = minor
+      archive = true
+    }
+    {
+      name = yAxisHardwareLimit
+      description = """
+This alarm is activated when Y axis hits a limit switch.
+
+If Y axis is still moving beyonds the limit switch, the operator should immediately stop the motion by sending stop command. If the motion controller does not stop even after that, the operator should turn off the motion controller. Because there is a mechanical block at each end, the linear stage will not derail from the linear guide even if the linear stage goes over the limit switch, but the hitting the mechanical block may cause unnecessary damage to the mechanisms, so the motion should be stopped immediately.
+
+This alarm should not happen during an observation. If it does, this alarm should be reported to an instrument expert. If the linear stage goed beyond the limit switch, the instrument expert has to forcibly move it back to an operational range using an engineering screen.
+"""
+      severity = major
+      archive = true
+    }
+    {
+      name = stall
+      description = """
+This alarm is activated when a severe stall (step-out) of any axis is detected. The actual scheme to detect the stall is TBD.
+"""
+      severity = major
+      archive = true
+    }
+    {
+      name = trackingFailure
+      description = """
+This alarm is activated when tracking motion cannot continue properly.
+
+Note that tracking failure caused by step-out cannot be detected during the tracking motion because there is no position sensor except the home switch. This alarm just indicates that responses from the motion controller are delayed for some reason. Most probably it is caused by network congestion within IRIS private network.
+
+If the alarm stays activated for a long time, or if this alarm happens repeatedly, the following actions may resolve this issue.
+
+* Reload of this assembly.
+* Reload the underlying Galil HCD.
+* Cycliing the power of the motion controller.
+* Reboot the computer which runs this assembly and Galil HCD.
+
+If this alarm cannot be deactivated by the above actions, it should be reported to an instrument expert.
+"""
+      severity = minor
+      archive = true
+    }
+  ]
 }

--- a/imager/pupilview-assembly/publish-model.conf
+++ b/imager/pupilview-assembly/publish-model.conf
@@ -402,6 +402,22 @@ __TBD__: Maybe it would be useful to map this value to the range between 0 to 1 
           minimum = 0.25
           maximum = 64
         }
+        {
+          name = softwareLimits
+          description = "Software limits of Y axis. If the positioner goes over this range, an alarm is activated."
+          type = array
+          dimensions: [2]
+          items = {
+            type = float
+          }
+          units = mm
+        }
+        {
+          name = supressSoftwareLimitAlarm
+          description = "Indicates whether the alarm for the software limits is supressed. This configuration is useful to supress the alarm when an instrument specialist forcibly moves Y axis (using engineering screen) over the software limit range for maintenance."
+          type = boolean
+          default = false
+        }
       ]
     }
     {

--- a/imager/pupilview-assembly/publish-model.conf
+++ b/imager/pupilview-assembly/publish-model.conf
@@ -418,4 +418,37 @@ __TODO__: Telemetries for detector and its configuration should be defined. This
       ]
     }
   ]
+
+  alarms = [
+    {
+      name = softwareLimit
+      description = """
+This alarm is activated when the mirror stage goes beyond a software limit. This alarm may be activated when someone forcibly moves the mirror stage beyond the software limit by using engineering screen, or by directly sending commands to the motion controller. Because the current position is inferred from the total number of pulses sent from the motion controller after the last homing, this alarm may be activated during homing after step-out occurs.
+
+This alarm should not happen during an observation. If it does, this alarm should be reported to an instrument expert.
+"""
+      severity = minor
+      archive = true
+    }
+    {
+      name = hardwareLimit
+      description = """
+This alarm is activated when the mirror stage hits a limit switch.
+
+If the mirror stage is still moving beyonds the limit switch, the operator should immediately stop the motion by sending stop command. If the motion controller does not stop even after that, the operator should turn off the motion controller. Because there is a mechanical block at each end, the linear stage will not derail from the linear guide even if the linear stage goes over the limit switch, but the hitting the mechanical block may cause unnecessary damage to the mechanisms, so the motion should be stopped immediately.
+
+This alarm should not happen during an observation. If it does, this alarm should be reported to an instrument expert. If the linear stage goed beyond the limit switch, the instrument expert has to forcibly move it back to an operational range using an engineering screen.
+"""
+      severity = major
+      archive = true
+    }
+    {
+      name = stall
+      description = """
+This alarm is activated when a severe stall (step-out) is detected. The actual scheme to detect the stall is TBD.
+"""
+      severity = major
+      archive = true
+    }
+  ]
 }


### PR DESCRIPTION
Alarms are newly defined for the mechanisms of the imager which have software/hardware limits. An alarm is also defined for ADC and cold stop to notify of tracking failure.

