### PR TITLE
Commands for DRS assembly, update of IS commands, update of DRS subscribe model

### DIFF
--- a/drs/drs-assembly/command-model.conf
+++ b/drs/drs-assembly/command-model.conf
@@ -1,0 +1,144 @@
+subsystem = IRIS
+component = drs-assembly
+
+description = """
+DRS Assembly commands.
+"""
+
+receive = [
+    {
+	name = INITIALIZE
+	description = "Initialize the DRS assembly by loading configuration file"
+    }
+    { 
+	name = DATUM
+	description = "Prepare DRS for reductions.  Functionality of this command TBD, but may involve initializing pipelines, memory, and connections to disks and external entities"
+    }
+    { 
+	name = START
+	description = "Start specified pipeline.  If not argument is specified, all pipelines are started."
+	args = [
+	    {
+		name = pipeline
+		description = "Type of pipeline to start."
+		enum = [readout-imager, readout-ifs, online-imager, online-ifs, full-imager, full-ifs, all]
+		default = all
+	    }
+	]
+    }
+    { 
+	name = STOP
+	description = "Stop specified pipeline.  If not argument is specified, all pipelines are stopped."
+	args = [
+	    {
+		name = pipeline
+		description = "Type of pipeline to stop."
+		enum = [readout-imager, readout-ifs, online-imager, online-ifs, full-imager, full-ifs, all]
+		default = all
+	    }
+	]
+    }
+    {
+	name = TEST
+	description = "Test communications to this assembly"
+    }
+    {
+	name = configureObserver
+	description = "Configure pipeline with specified observer properties."
+	args = [
+	    {
+		name = observer
+		description = "Observer name(s)"
+		type = string
+		default = "unknown"
+	    }
+	    {
+		name = piName
+		description = "Name(s) of PI"
+		type = string
+		default = "unknown"
+	    }
+	    {
+		name = partner
+		description = "Name(s) of partner(s)"
+		type = string
+		default = "unknown"
+	    }
+	    {
+		name = proposal
+		description = "Proposal ID"
+		type = string
+		default = "unknown"
+	    }
+	    {
+		name = dataDirectory
+		description = "URI for data directory"
+		type = string
+	    }
+	]
+    }
+    {
+	name = configureObservation
+	description = "Configure pipeline(s) with specified observation block properties."
+	args = [
+	    {
+		name = observationID
+		description = "Identification string of observation"
+		type = string
+		default = "unknown"
+	    }
+	    {
+		name = observationType
+		description = "Type of observation (science, star, calibration)"
+		enum = [science, star, calibration]
+	    }
+	    {
+		name = object
+		description = "Object Name"
+		type = string
+		default = "unknown"
+	    }
+	    {
+		name = objectRA
+		description = "Object right ascension"
+		type = float
+	    }
+	    {
+		name = objectDec
+		description = "Object declination"
+		type = float
+	    }
+	    {
+		name = objectPattern
+		description = "Dither pattern for object frames.  This will likely eventually be a TBD enum type"
+		type = string 
+		default = "unknown"
+	    }
+	    {
+		name = skyPattern
+		description = "Dither pattern for object frames.  This will likely eventually be a TBD enum type"
+		type = string
+		default = "unknown"
+	    }
+	    {
+		name = objectFrames
+		description = "Number of frames in object dither pattern"
+		type = int
+		default = 1
+		minValue = 0
+	    }
+	    {
+		name = skyFrames
+		description = "Number of frames in sky dither pattern"
+		type = int
+		default = 0
+		minValue = 0
+	    }
+	    {
+		name = ditherCoordinates
+		description = "Coordinate system for dither offset values"
+		enum = [sky, instrument]
+	    }
+	]
+    }
+]

--- a/drs/drs-assembly/command-model.conf
+++ b/drs/drs-assembly/command-model.conf
@@ -123,16 +123,16 @@ receive = [
 	    {
 		name = objectPositions
 		description = "Number of positions in object dither pattern"
-		type = int
+		type = integer
 		default = 1
-		minValue = 0
+		minimum = 0
 	    }
 	    {
 		name = skyPositions
 		description = "Number of positions in sky dither pattern"
-		type = int
+		type = integer
 		default = 0
-		minValue = 0
+		minimum = 0
 	    }
 	    {
 		name = ditherCoordinates

--- a/drs/drs-assembly/command-model.conf
+++ b/drs/drs-assembly/command-model.conf
@@ -121,15 +121,15 @@ receive = [
 		default = "unknown"
 	    }
 	    {
-		name = objectFrames
-		description = "Number of frames in object dither pattern"
+		name = objectPositions
+		description = "Number of positions in object dither pattern"
 		type = int
 		default = 1
 		minValue = 0
 	    }
 	    {
-		name = skyFrames
-		description = "Number of frames in sky dither pattern"
+		name = skyPositions
+		description = "Number of positions in sky dither pattern"
 		type = int
 		default = 0
 		minValue = 0

--- a/drs/drs-assembly/subscribe-model.conf
+++ b/drs/drs-assembly/subscribe-model.conf
@@ -3,9 +3,12 @@ subsystem = IRIS
 component = drs-assembly
 
 subscribe {
-  description = """The DRS needs general meta-data to write to raw science
-frames from TCS, ESW, AOESW to put into the FITS header for user
-post-processing.
+  description = """
+Telemetry items needed by the DRS to operate, track exposure progress, and reduce data. 
+
+Items with the FITS= tag in the description refer to general meta-data from 
+IRIS, TCS, ESW, NFIRASO, AOESW and NSCU to be associated with science data 
+(or put into the FITS header) for user post-processing.
   """
   telemetry = [
 
@@ -449,54 +452,28 @@ post-processing.
   usage = """
 Current position of the cold stop. Contains the following:
 
-* Position of the coldstop in theta. FITS=CS_THETA
-* Position of the cold stop in x. FITS=CS_XPOS
-* Position of the coldstop in y. FITS=CS_YPOS
+* theta: Position of the coldstop in theta. FITS=CS_THETA
+* x_pos: Position of the cold stop in x. FITS=CS_XPOS
+* y_pos: Position of the coldstop in y. FITS=CS_YPOS
 """
 }
 
 {
   subsystem =  IRIS
   component =  cryotemp-assembly
-  name =  temperature
+  name =  sensor
   requiredRate =  4
   usage = """
-  Imager detector temperature. Contains the following:
-  
+  Cryogenic temperature sensor information. Each sensor telemetry item includes an attribute <functionalgroup> which indicates if it is for the imager or IFS, and an attribute <sensorID> which identifies the sensor (A, B, C1-4, D1-4, with A and B typically used for inputs to a control loop). The attribute <location> gives the location of the sensor in the dewar, and the attribute <reading> gives the actual temperature reading at the sensor.
+
+The following FITS keywords (for each functional group and sensor ID) will be constructed from these telemetry items:
+
   *Temperature of the imager detector. FITS=IMGTEMP
   *Temperature of the ifs detector. FITS=IFSTEMP
-  *Temperature of the science dewar reported by temperature sensor 1. FITS=DEWTEMP1
-  *Description of the location of temperature sensor 1. FITS=DEWNAME1
-  *Temperature of the science dewar reported by temperature sensor 2. FITS=DEWTEMP2
-  *Description of the location of temperature sensor 2. FITS=DEWNAME2
-  *Temperature of the science dewar reported by temperature sensor 3. FITS=DEWTEMP3
-  *Description of the location of temperature sensor 3. FITS=DEWNAME3
-  *Temperature of the science dewar reported by temperature sensor 4. FITS=DEWTEMP4
-  *Description of the location of temperature sensor 4. FITS=DEWNAME4
-  *Temperature of the science dewar reported by temperature sensor 5. FITS=DEWTEMP5
-  *Description of the location of temperature sensor 5. FITS=DEWNAME5
-  *Temperature of the science dewar reported by temperature sensor 6. FITS=DEWTEMP6
-  *Description of the location of temperature sensor 6. FITS=DEWNAME6
-  *Temperature of the science dewar reported by temperature sensor 7. FITS=DEWTEMP7
-  *Description of the location of temperature sensor 7. FITS=DEWNAME7
-  *Temperature of the science dewar reported by temperature sensor 8. FITS=DEWTEMP8
-  *Description of the location of temperature sensor 8. FITS=DEWNAME8
-  *Temperature of the science dewar reported by temperature sensor 9. FITS=DEWTEMP9
-  *Description of the location of temperature sensor 9. FITS=DEWNAME9
-  *Temperature of the science dewar reported by temperature sensor 10. FITS=DEWTEMP10
-  *Description of the location of temperature sensor 10. FITS=DEWNAME10
-  *Temperature of the science dewar reported by temperature sensor 11. FITS=DEWTEMP11
-  *Description of the location of temperature sensor 11. FITS=DEWNAME11
-  *Temperature of the science dewar reported by temperature sensor 12. FITS=DEWTEMP12
-  *Description of the location of temperature sensor 12. FITS=DEWNAME12
-  *Temperature of the science dewar reported by temperature sensor 13. FITS=DEWTEMP13
-  *Description of the location of temperature sensor 13. FITS=DEWNAME13
-  *Temperature of the science dewar reported by temperature sensor 14. FITS=DEWTEMP14
-  *Description of the location of temperature sensor 14. FITS=DEWNAME14
-  *Temperature of the science dewar reported by temperature sensor 15. FITS=DEWTEMP15
-  *Description of the location of temperature sensor 15. FITS=DEWNAME15
-  *Temperature of the science dewar reported by temperature sensor 16. FITS=DEWTEMP16
-  *Description of the location of temperature sensor 16. FITS=DEWNAME16
+  *Temperature of the dewar reported by Imager temperature sensor <sensorID>. FITS=IMGTEMP<sensorID>
+  *Description of the location of Imager temperature sensor <sensorID>. FITS=IMGNAME<sensorID>
+  *Temperature of the dewar reported by IFS temperature sensor <sensorID>. FITS=IFSTEMP<sensorID>
+  *Description of the location of IFS temperature sensor <sensorID>. FITS=IFSNAME<sensorID>
   
   """
   
@@ -542,9 +519,17 @@ Current position of the cold stop. Contains the following:
 {
   subsystem =  IRIS
   component =  ifs-scale-assembly
-  name =  foldmirrormech
+  name =  pickoffMirrorMech
   requiredRate =  1
-  usage = "Status of the IFS slicer fold mirror mechanism. Contains its in/out position. FITS=PICK_SFM"
+  usage = "Atrribute <position>: Status of the IFS slicer pickoff mirror mechanism. Contains its in/out position. FITS=SPICKPOS"
+}
+
+{
+  subsystem =  IRIS
+  component =  ifs-scale-assembly
+  name =  periscopeMirrorMech
+  requiredRate =  1
+  usage = "Atrribute <position>: Status of the IFS slicer periscope mirror mechanism. Contains its in/out position. FITS=SPERIPOS"
 }
 
 {
@@ -552,7 +537,7 @@ Current position of the cold stop. Contains the following:
   component =  ifs-scale-assembly
   name =  IFSmode
   requiredRate =  1
-  usage = "Contains IFS mode: lenslet or slicer. FITS=IFSMODE"
+  usage = "Attribute <mode>: lenslet or slicer. FITS=IFSMODE"
 }
 
 {
@@ -560,7 +545,7 @@ Current position of the cold stop. Contains the following:
   component =  ifs-scale-assembly
   name =  scale
   requiredRate =  1
-  usage = "Contains current IFS scale. FITS=IFSSCALE"
+  usage = "Attribute <current>: IFS scale. FITS=IFSSCALE"
 }
 
 {
@@ -616,64 +601,32 @@ Current exposure configuration of the imager. Contains the following:
 }
 
 {
-  subsystem =  IRIS
-  component =  is
-  name =  DATAFILE
-  requiredRate =  1
-  usage = "Filename for saved data image. FITS=DATAFILE"
-}
-
-{
-  subsystem =  IRIS
-  component =  is
-  name =  DATE
-  requiredRate =  1
-  usage = "UT date of file creation. FITS=DATE"
-}
-
-{
-  subsystem =  IRIS
-  component =  is
-  name =  DCOORDS
-  requiredRate =  1
-  usage = "Dither coordinates - sky/instr. FITS=DCOORDS"
-}
-
-{
-  subsystem =  IRIS
-  component =  is
-  name =  DECOBJ
-  requiredRate =  1
-  usage = "Dec of object. FITS=DECOBJ"
-}
-
-{
-  subsystem =  IRIS
-  component =  is
+  subsystem =  TCS
+  component =  tcs-tbd
   name =  DLSTOFF1
   requiredRate =  1
   usage = "Offset from last dither pos-axis 1. FITS=DLSTOFF1"
 }
 
 {
-  subsystem =  IRIS
-  component =  is
+  subsystem =  TCS
+  component =  tcs-tbd
   name =  DLSTOFF2
   requiredRate =  1
   usage = "Offset from last dither pos-axis 2. FITS=DLSTOFF2"
 }
 
 {
-  subsystem =  IRIS
-  component =  is
+  subsystem =  TCS
+  component =  tcs-tbd
   name =  DTOTOFF1
   requiredRate =  1
   usage = "Offset from start of dither-axis 1. FITS=DTOTOFF1"
 }
 
 {
-  subsystem =  IRIS
-  component =  is
+  subsystem =  TCS
+  component =  tcs-tbd
   name =  DTOTOFF2
   requiredRate =  1
   usage = "Offset from start of dither-axis 2. FITS=DTOTOFF2"
@@ -682,202 +635,59 @@ Current exposure configuration of the imager. Contains the following:
 {
   subsystem =  IRIS
   component =  is
-  name =  IFRAME
+  name =  currentImagerExposureNumber
   requiredRate =  1
-  usage = "Current image frame of dither position. FITS=IFRAME"
+  usage = "Current imager exposure at dither position in current instrument configuration. FITS=IFRAME"
 }
 
 {
   subsystem =  IRIS
   component =  is
-  name =  IFRAMES
+  name =  numberOfImagerExposures
   requiredRate =  1
-  usage = "Number of image frames per spec frame. FITS=IFRAMES"
+  usage = "Number of imager exposures at dither position in current instrument configuration. FITS=IFRAMES"
 }
 
 {
   subsystem =  IRIS
   component =  is
-  name =  INSTMODE
+  name =  currentIFSExposureNumber
   requiredRate =  1
-  usage = "IFS or imager (IMAG). FITS=INSTMODE"
+  usage = "Current IFS exposure at dither position in current instrument configuration. FITS=SFRAME"
 }
 
 {
   subsystem =  IRIS
   component =  is
-  name =  INSTR
+  name =  numberOfIFSExposures
   requiredRate =  1
-  usage = "Instrument name. FITS=INSTR"
+  usage = "Number of IFS exposures at dither position in current instrument configuration. FITS=SFRAMES"
 }
 
 {
-  subsystem =  IRIS
-  component =  is
-  name =  ISSKY
+  subsystem =  ESW
+  component =  ms
+  name =  currentObjectPosition
+  requiredRate =  1
+  usage = "Current position number in object dither pattern (1-based). FITS=OBJPOS"
+}
+
+{
+  subsystem =  ESW
+  component =  ms
+  name =  currentSkyPosition
+  requiredRate =  1
+  usage = "Current position number in sky dither pattern (1-based). FITS=SKYPOS"
+}
+
+{
+  subsystem =  ESW
+  component =  ms
+  name =  currentPositionIsSky
   requiredRate =  1
   usage = "Flag for sky frames (0=not sky, 1=sky). FITS=ISSKY"
 }
 
-{
-  subsystem =  IRIS
-  component =  is
-  name =  OBJECT
-  requiredRate =  1
-  usage = "Object name. FITS=OBJECT"
-}
-
-{
-  subsystem =  IRIS
-  component =  is
-  name =  OBJPTTRN
-  requiredRate =  1
-  usage = "Dither pattern for object frames. FITS=OBJPTTRN"
-}
-
-{
-  subsystem =  IRIS
-  component =  is
-  name =  OBSERVER
-  requiredRate =  1
-  usage = "Observer name(s). FITS=OBSERVER"
-}
-
-{
-  subsystem =  IRIS
-  component =  is
-  name =  OBSID
-  requiredRate =  1
-  usage = "Observation ID. FITS=OBSID"
-}
-
-{
-  subsystem =  IRIS
-  component =  is
-  name =  OBSTYPE
-  requiredRate =  1
-  usage = "Observation type: science, star, calibration. FITS=OBSTYPE"
-}
-
-{
-  subsystem =  IRIS
-  component =  is
-  name =  OUTDIR
-  requiredRate =  1
-  usage = "Output directory. FITS=OUTDIR"
-}
-
-{
-  subsystem =  IRIS
-  component =  is
-  name =  PARTNER
-  requiredRate =  1
-  usage = "Name of Partner(s). FITS=PARTNER"
-}
-
-{
-  subsystem =  IRIS
-  component =  is
-  name =  PI_NAME
-  requiredRate =  1
-  usage = "Name of PI(s). FITS=PI_NAME"
-}
-
-{
-  subsystem =  IRIS
-  component =  is
-  name =  PROPID
-  requiredRate =  1
-  usage = "Proposal ID. FITS=PROPID"
-}
-
-{
-  subsystem =  IRIS
-  component =  is
-  name =  RAOBJ
-  requiredRate =  1
-  usage = "RA of object. FITS=RAOBJ"
-}
-
-{
-  subsystem =  IRIS
-  component =  is
-  name =  SCPTNAME
-  requiredRate =  1
-  usage = "Name of observation script. FITS=SCPTNAME"
-}
-
-{
-  subsystem =  IRIS
-  component =  is
-  name =  SETNUM
-  requiredRate =  1
-  usage = "Dataset Number. FITS=SETNUM"
-}
-
-{
-  subsystem =  IRIS
-  component =  is
-  name =  SFRAME
-  requiredRate =  1
-  usage = "Current spec frame (dither position) of set. FITS=SFRAME"
-}
-
-{
-  subsystem =  IRIS
-  component =  is
-  name =  SFRAMES
-  requiredRate =  1
-  usage = "Number of spec frames in dataset. FITS=SFRAMES"
-}
-
-{
-  subsystem =  IRIS
-  component =  is
-  name =  SKYPTTRN
-  requiredRate =  1
-  usage = "Dither pattern for sky frames. FITS=SKYPTTRN"
-}
-
-{
-  subsystem =  IRIS
-  component =  is
-  name =  SOFTWARE
-  requiredRate =  1
-  usage = "Software and version. FITS=SOFTWARE"
-}
-
-{
-  subsystem =  IRIS
-  component =  is.ifs
-  name =  COADDNUM
-  requiredRate =  1
-  usage = "This IFS coadd number. FITS=COADDNUM"
-}
-
-{
-  subsystem =  IRIS
-  component =  is.ifs
-  name =  COADDS
-  requiredRate =  1
-  usage = "IFS number of coadded frames. FITS=COADDS"
-}
-
-{
-  subsystem =  IRIS
-  component =  is.imager
-  name =  COADDNUM
-  requiredRate =  1
-  usage = "This imager coadd number. FITS=COADDNUM"
-}
-
-{
-  subsystem =  IRIS
-  component =  is.imager
-  name =  COADDS
-  requiredRate =  1
-  usage = "Imager number of coadded frames. FITS=COADDS"
-}
 
 {
   subsystem =  NFIRAOS
@@ -1457,18 +1267,19 @@ Current exposure configuration of the imager. Contains the following:
 
 {
   subsystem =  IRIS
-  component =  pressure-assembly.pressure
-  name =  gaugeDescription
+  component =  pressure-assembly
+  name =  pressure
   requiredRate =  4
-  usage = "Named location of pressure sensor. FITS=PRESNAM1,PRESNAM2"
-}
+  usage = """
+  Pressure gauge information. Each pressure telemetry item includes an attribute <gaugeNumber> which identifies the gauge. The attribute <gaugeDescription> gives a description of what the gauge is reading, and the attribute <value> gives the actual pressure reading of the gauge.
 
-{
-  subsystem =  IRIS
-  component =  pressure-assembly.pressure
-  name =  value
-  requiredRate =  4
-  usage = "Pressure sensor inside dewar. FITS=PRESSUR1,PRESSUR2"
+The following FITS keywords (for each gauge number) will be constructed from these telemetry items:
+
+
+* gaugeDescription: Named location of pressure sensor. FITS=PRESNAM<gaugeNumber>
+* value: Pressure sensor inside dewar at gauge. FITS=PRESSUR<gaugeNumber>
+
+"""
 }
 
 {
@@ -1559,26 +1370,26 @@ Current configuration of filter wheel #5. Contains the following:
 
 {
   subsystem =  IRIS
-  component =  spectral-resolution-assembly.resolution
-  name =  current
+  component =  spectral-resolution-assembly
+  name =  resolution
   requiredRate =  1
-  usage = "IFS grating position. FITS=IFSRES"
+  usage = "Attribute <current>: IFS grating position. FITS=IFSNAME"
 }
 
 {
   subsystem =  IRIS
-  component =  spectral-resolution-assembly.resolutionMech
-  name =  mechNumber
+  component =  spectral-resolution-assembly
+  name =  lensletmaskmech
   requiredRate =  1
-  usage = "IFS grating position. FITS=IFSGPOS"
+  usage = "Attribute <position>: IFS lenslet mask position. FITS=LMASKPOS"
 }
 
 {
   subsystem =  IRIS
-  component =  spectral-resolution-assembly.resolutionMech
-  name =  position
+  component =  spectral-resolution-assembly
+  name =  slicermaskmech
   requiredRate =  1
-  usage = "IFS grating name. FITS=IFSGNAME"
+  usage = "Attribute <position>: IFS slicer mask position. FITS=SMASKPOS"
 }
 
 {

--- a/drs/drs-assembly/subscribe-model.conf
+++ b/drs/drs-assembly/subscribe-model.conf
@@ -635,57 +635,30 @@ Current exposure configuration of the imager. Contains the following:
 {
   subsystem =  IRIS
   component =  is
-  name =  currentImagerExposureNumber
-  requiredRate =  1
-  usage = "Current imager exposure at dither position in current instrument configuration. FITS=IFRAME"
-}
+  name = exposureRepeats
+  usage = """
+Information to track exposure repeats at current dither position with current instrument configuration.  Contains:
 
-{
-  subsystem =  IRIS
-  component =  is
-  name =  numberOfImagerExposures
-  requiredRate =  1
-  usage = "Number of imager exposures at dither position in current instrument configuration. FITS=IFRAMES"
-}
+* currentImagerExposureNumber: Current imager exposure at dither position in current instrument configuration. FITS=IFRAME
+* numberOfImagerExposures: Number of imager exposures at dither position in current instrument configuration. FITS=IFRAMES
+* currentIFSExposureNumber: Current IFS exposure at dither position in current instrument configuration. FITS=SFRAME
+* numberOfIFSExposures: Number of IFS exposures at dither position in current instrument configuration. FITS=SFRAMES
 
-{
-  subsystem =  IRIS
-  component =  is
-  name =  currentIFSExposureNumber
-  requiredRate =  1
-  usage = "Current IFS exposure at dither position in current instrument configuration. FITS=SFRAME"
-}
-
-{
-  subsystem =  IRIS
-  component =  is
-  name =  numberOfIFSExposures
-  requiredRate =  1
-  usage = "Number of IFS exposures at dither position in current instrument configuration. FITS=SFRAMES"
+"""
 }
 
 {
   subsystem =  ESW
   component =  ms
-  name =  currentObjectPosition
-  requiredRate =  1
-  usage = "Current position number in object dither pattern (1-based). FITS=OBJPOS"
-}
+  name =  ditherPosition
+  usage = """
+Information about current dither pattern position. Contains:
 
-{
-  subsystem =  ESW
-  component =  ms
-  name =  currentSkyPosition
-  requiredRate =  1
-  usage = "Current position number in sky dither pattern (1-based). FITS=SKYPOS"
-}
+* currentObjectPosition: Current position number in object dither pattern (1-based). FITS=OBJPOS
+* currentSkyPosition: Current position number in sky dither pattern (1-based). FITS=SKYPOS
+* currentPositionIsSky: Flag for sky frames (0=not sky, 1=sky). FITS=ISSKY
 
-{
-  subsystem =  ESW
-  component =  ms
-  name =  currentPositionIsSky
-  requiredRate =  1
-  usage = "Flag for sky frames (0=not sky, 1=sky). FITS=ISSKY"
+"""
 }
 
 

--- a/ici/is/command-model.conf
+++ b/ici/is/command-model.conf
@@ -202,7 +202,7 @@ Accepted states are based on use cases described in IRIS Software Design Documen
 	]
     }
     {
-	name = SetupConfig(observation)
+	name = SetupConfig(observationBlock)
 	description = "Configure IRIS with specified observation block properties.NOTE: This isn't actually a command, but rather the specification of a SetupConfig.  A SetupConfigArgs list used by the submit and oneway commands may be one or more of these.  It is listed here in this way to adapt to the current model file schema so that we can take advantage of the ICD-DB functionality. "
 	args = [
 	    {

--- a/ici/is/command-model.conf
+++ b/ici/is/command-model.conf
@@ -245,15 +245,15 @@ Accepted states are based on use cases described in IRIS Software Design Documen
 		default = "unknown"
 	    }
 	    {
-		name = objectFrames
-		description = "Number of frames in object dither pattern"
+		name = objectPositions
+		description = "Number of positions in object dither pattern"
 		type = int
 		default = 1
 		minValue = 0
 	    }
 	    {
-		name = skyFrames
-		description = "Number of frames in sky dither pattern"
+		name = skyPositions
+		description = "Number of positions in sky dither pattern"
 		type = int
 		default = 0
 		minValue = 0

--- a/ici/is/command-model.conf
+++ b/ici/is/command-model.conf
@@ -54,7 +54,7 @@ receive = [
 
 
     {
-	name = SetupConfig("global")
+	name = SetupConfig(global)
 	description = "Perform global command to some of all of the IRIS software systems.  These commands may be folded into the SetupConfig(\"state\") command.  NOTE: This isn't actually a command, but rather the specification of a SetupConfig.  A SetupConfigArgs list used by the submit and oneway commands may be one or more of these.  It is listed here in this way to adapt to the current model file schema so that we can take advantage of the ICD-DB functionality."
        args = [
            {
@@ -79,7 +79,7 @@ Command to be executed.
         ]
     } 
     {
-      name = SetupConfig("engineeringState")
+      name = SetupConfig(engineeringState)
       description = """
 
 Configure instrument to match a specific state for engineering purposes.    NOTE: This isn't actually a command, but rather the specification of a SetupConfig.  A SetupConfigArgs list used by the submit and oneway commands may be one or more of these.  It is listed here in this way to adapt to the current model file schema so that we can take advantage of the ICD-DB functionality.
@@ -108,7 +108,7 @@ Accepted states are based on use cases described in IRIS Software Design Documen
       ]
     }
     { 
-      name = SetupConfig("mechanical")
+      name = SetupConfig(mechanical)
       description = "Setup instrument mechanisms for observation.   NOTE: This isn't actually a command, but rather the specification of a SetupConfig.  A SetupConfigArgs list used by the submit and oneway commands may be one or more of these.  It is listed here in this way to adapt to the current model file schema so that we can take advantage of the ICD-DB functionality."
       args = [
         {
@@ -167,8 +167,8 @@ Accepted states are based on use cases described in IRIS Software Design Documen
       ]
     } 
     {
-	name = ObserverConfig
-	description = "Configure IRIS with specified observer properties."
+	name = SetupConfig(observer)
+	description = "Configure IRIS with specified observer properties.NOTE: This isn't actually a command, but rather the specification of a SetupConfig.  A SetupConfigArgs list used by the submit and oneway commands may be one or more of these.  It is listed here in this way to adapt to the current model file schema so that we can take advantage of the ICD-DB functionality. "
 	args = [
 	    {
 		name = observer
@@ -202,8 +202,8 @@ Accepted states are based on use cases described in IRIS Software Design Documen
 	]
     }
     {
-	name = ObservationConfig
-	description = "Configure IRIS with specified observation block properties."
+	name = SetupConfig(observation)
+	description = "Configure IRIS with specified observation block properties.NOTE: This isn't actually a command, but rather the specification of a SetupConfig.  A SetupConfigArgs list used by the submit and oneway commands may be one or more of these.  It is listed here in this way to adapt to the current model file schema so that we can take advantage of the ICD-DB functionality. "
 	args = [
 	    {
 		name = observationID

--- a/ici/is/command-model.conf
+++ b/ici/is/command-model.conf
@@ -247,16 +247,16 @@ Accepted states are based on use cases described in IRIS Software Design Documen
 	    {
 		name = objectPositions
 		description = "Number of positions in object dither pattern"
-		type = int
+		type = integer
 		default = 1
-		minValue = 0
+		minimum = 0
 	    }
 	    {
 		name = skyPositions
 		description = "Number of positions in sky dither pattern"
-		type = int
+		type = integer
 		default = 0
-		minValue = 0
+		minimum = 0
 	    }
 	    {
 		name = ditherCoordinates

--- a/ici/is/command-model.conf
+++ b/ici/is/command-model.conf
@@ -166,6 +166,105 @@ Accepted states are based on use cases described in IRIS Software Design Documen
         }
       ]
     } 
+    {
+	name = ObserverConfig
+	description = "Configure IRIS with specified observer properties."
+	args = [
+	    {
+		name = observer
+		description = "Observer name(s)"
+		type = string
+		default = "unknown"
+	    }
+	    {
+		name = piName
+		description = "Name(s) of PI"
+		type = string
+		default = "unknown"
+	    }
+	    {
+		name = partner
+		description = "Name(s) of partner(s)"
+		type = string
+		default = "unknown"
+	    }
+	    {
+		name = proposal
+		description = "Proposal ID"
+		type = string
+		default = "unknown"
+	    }
+	    {
+		name = dataDirectory
+		description = "URI for data directory"
+		type = string
+	    }
+	]
+    }
+    {
+	name = ObservationConfig
+	description = "Configure IRIS with specified observation block properties."
+	args = [
+	    {
+		name = observationID
+		description = "Identification string of observation"
+		type = string
+		default = "unknown"
+	    }
+	    {
+		name = observationType
+		description = "Type of observation (science, star, calibration)"
+		enum = [science, star, calibration]
+	    }
+	    {
+		name = object
+		description = "Object Name"
+		type = string
+		default = "unknown"
+	    }
+	    {
+		name = objectRA
+		description = "Object right ascension"
+		type = float
+	    }
+	    {
+		name = objectDec
+		description = "Object declination"
+		type = float
+	    }
+	    {
+		name = objectPattern
+		description = "Dither pattern for object frames.  This will likely eventually be a TBD enum type"
+		type = string 
+		default = "unknown"
+	    }
+	    {
+		name = skyPattern
+		description = "Dither pattern for object frames.  This will likely eventually be a TBD enum type"
+		type = string
+		default = "unknown"
+	    }
+	    {
+		name = objectFrames
+		description = "Number of frames in object dither pattern"
+		type = int
+		default = 1
+		minValue = 0
+	    }
+	    {
+		name = skyFrames
+		description = "Number of frames in sky dither pattern"
+		type = int
+		default = 0
+		minValue = 0
+	    }
+	    {
+		name = ditherCoordinates
+		description = "Coordinate system for dither offset values"
+		enum = [sky, instrument]
+	    }
+	]
+    }
     { 
       name = ObserveConfig
       description = "Perform a series of one or more exposures with either the Imager, IFS, or both.  NOTE: This isn't actually a command, but rather the specification of an ObserveConfig.  An ObserveConfigArgs list used by the submit and oneway commands may be one or more of these.  It is listed here in this way to adapt to the current model file schema so that we can take advantage of the ICD-DB functionality."
@@ -782,5 +881,35 @@ send = [
 	subsystem=IRIS
 	component=csro-env-assembly
      }
-    
+    // drs assembly
+    {
+	name = START
+	subsystem = IRIS
+	component = drs-assembly
+    }
+    {
+	name = STOP
+	subsystem = IRIS
+	component = drs-assembly
+    }
+    {
+	name = DATUM
+	subsystem = IRIS
+	component = drs-assembly
+    }
+    {
+	name = TEST
+	subsystem = IRIS
+	component = drs-assembly
+    }
+    {
+	name = configureObserver
+	subsystem = IRIS
+	component = drs-assembly
+    }
+    {
+	name = configureObservation
+	subsystem = IRIS
+	component = drs-assembly
+    }
 ]

--- a/ici/is/publish-model.conf
+++ b/ici/is/publish-model.conf
@@ -4,28 +4,34 @@ component = is
 publish {
     telemetry = [
 	{
-	    name = currentIFSExposureNumber
-	    description = "Number of current (if in progress) or last IFS exposure at current dither pattern with current instrument configuration (1-based)."
-	    type = integer
-	    min = 1
-	}
-	{
-	    name = currentImagerExposureNumber
-	    description = "Number of current (if in progress) or last imager exposure at current dither pattern with current instrument configuration (1-based)."
-	    type = integer
-	    min = 1
-	}
-	{
-	    name = numberOfIFSExposures
-	    description = "Total number of IFS exposures at current dither pattern."
-	    type = integer
-	    min = 1
-	}
-	{
-	    name = numberOfImagerExposures
-	    description = "Total number of IFS exposures at current dither pattern with current instrument configuration."
-	    type = integer
-	    min = 1
+	    name = exposureRepeats
+	    description = "Information about tracking the number of exposure repeats at current dither position and instrument configuration"
+	    attributes = [
+		{
+		    name = currentIFSExposureNumber
+		    description = "Number of current (if in progress) or last IFS exposure at current dither pattern with current instrument configuration (1-based)."
+		    type = integer
+		    minimum = 0
+		}
+		{
+		    name = currentImagerExposureNumber
+		    description = "Number of current (if in progress) or last imager exposure at current dither pattern with current instrument configuration (1-based)."
+		    type = integer
+		    minimum = 0
+		}
+		{
+		    name = numberOfIFSExposures
+		    description = "Total number of IFS exposures at current dither pattern."
+		    type = integer
+		    minimum = 0
+		}
+		{
+		    name = numberOfImagerExposures
+		    description = "Total number of IFS exposures at current dither pattern with current instrument configuration."
+		    type = integer
+		    minimum = 0
+		}
+	    ]
 	}
     ]
 }

--- a/ici/is/publish-model.conf
+++ b/ici/is/publish-model.conf
@@ -1,0 +1,31 @@
+subsystem = IRIS
+component = is
+
+publish {
+    telemetry = [
+	{
+	    name = currentIFSExposureNumber
+	    description = "Number of current (if in progress) or last IFS exposure at current dither pattern with current instrument configuration (1-based)."
+	    type = integer
+	    min = 1
+	}
+	{
+	    name = currentImagerExposureNumber
+	    description = "Number of current (if in progress) or last imager exposure at current dither pattern with current instrument configuration (1-based)."
+	    type = integer
+	    min = 1
+	}
+	{
+	    name = numberOfIFSExposures
+	    description = "Total number of IFS exposures at current dither pattern."
+	    type = integer
+	    min = 1
+	}
+	{
+	    name = numberOfImagerExposures
+	    description = "Total number of IFS exposures at current dither pattern with current instrument configuration."
+	    type = integer
+	    min = 1
+	}
+    ]
+}

--- a/ifs/scale-assembly/command-model.conf
+++ b/ifs/scale-assembly/command-model.conf
@@ -93,6 +93,7 @@ This command locks all of the scale mechanisms. It is required for 'Warm Stow' a
 This command is accepted when all axes are stopped (Init:Running, In:Ready, Datum:Paused, Lock:Paused, Normal:Ready and Park:Parked). Successful execution will result in Lock:Locked state.
 
 __TBD__: Actual actions to be taken is TBD.
+"""
     }
     {
         name = FOLDMIRRORS_PARK

--- a/ifs/scale-assembly/publish-model.conf
+++ b/ifs/scale-assembly/publish-model.conf
@@ -30,7 +30,7 @@ publish {
     	{
     		name = IFSmode
     		description = "Current IFS mode determined by scale and resolution."
-    		maxrate = 1
+    		maxRate = 1
     		archive = true
     		attributes = [
     			{


### PR DESCRIPTION
these changes deal with trying to cleanup all of the subscribe items that deal with the instrument, particularly the IRIS.is items.  many of them are moved to commands sent from ESW via IS to DRS, and therefore removed from the subscription model.  the one major outstanding IRIS item that is not quite formatted correctly is the CSRO stuff.

Greg, i made quite a few changes to the subscribe model so i'd expect that it'd break your script... or at least, running your script would vastly undo the work ji man and i did to get the subscribe model compatible with the other publish model files.  please take a look at what we did and decide whether to modify your script, or disregard it, if what we've produced is far enough along it can just be edited by hand.