### PR TITLE
Updates to TCS-IRIS ICD for IRIS FDR

### DIFF
--- a/imager/adc-assembly/publish-model.conf
+++ b/imager/adc-assembly/publish-model.conf
@@ -17,8 +17,9 @@ __TODO__: Add configuration of the image shift model.
         description = """
 IRIS publishes the expected ADC image shifts of the (up to 4) IRIS ODGW position demands
 
+
 <em>
-Discussion: The ADC will shift an image position in a manner that depends upon the current state of the ADC. The estimated image shift (inferred from optical models) is sent from IRIS to the TCS so that the TCS can adjust the IRIS ODGW position demands accordingly. The reference wavelength used to calculate the shift is tcs.cm.iris.imgCurAtmDispersion.referenceWavelength.
+Discussion: The ADC will shift an image position in a manner that depends upon the current state of the ADC. Since the ODGWs are viewed through the science ADC, any telescope pointing shifts based on the sciShift event published by this assembly should also remove shifts in the ODGW positions. However, if the science ADC causes appreciable distortion, this published event can be used by the TCS to make small adjustments to the ODGW position demands to account for this distortion. The reference wavelength used to calculate the shift is tcs.cm.iris.imgCurAtmDispersion.referenceWavelength.
 </em>
         """
         maxRate = 1
@@ -57,6 +58,30 @@ Discussion: The ADC will shift an image position in a manner that depends upon t
             }
             {
                 name = odgw4Shift
+                description  = "2 element array holding x, y values (range TBD) in the FCRS<sub>IRIS-ROT</sub>, evaluated at the reference wavelength"
+                type = array
+                dimensions: [2]
+                items = {
+                    type = double
+                    units = mm
+                }
+            }
+        ]
+     }
+
+{
+        name = sciShift
+        description = """
+IRIS publishes the expected ADC image shift of the scient target
+
+*Discussion: The ADC will shift an image position in a manner that depends upon the current state of the ADC. The estimated image shift (inferred from optical models) is sent from IRIS to the TCS so that the TCS can adjust the telescope pointing, thereby stabilizing the science target on the IRIS imager. The reference wavelength used to calculate the shift is tcs.cm.iris.imgCurAtmDispersion.referenceWavelength.*
+        """
+        maxRate = 1
+        archive = true
+        archiveRate = 1
+        attributes = [
+            {
+                name = shift
                 description  = "2 element array holding x, y values (range TBD) in the FCRS<sub>IRIS-ROT</sub>, evaluated at the reference wavelength"
                 type = array
                 dimensions: [2]


### PR DESCRIPTION
Previously we only published the ODGW shifts, but really the main
thing is to publish the shift for the science target, as this
information should be used to re-point the telescope. The additional
shift information for the ODGWs is then only needed in the event
of appreciable image distortion caused by the science ADC.

See sister PR: https://github.com/tmt-icd/TCS-Model-Files/pull/7